### PR TITLE
検索結果画面にユーザー選択機能を追加し、選択したメンバーのメンションをクリップボードにコピーする機能を実装

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -71,19 +71,20 @@ def search_users():
             for doc in hobby_docs:
                 if doc.id in processed_user_ids:
                     continue
-                
+
                 profile_data = doc.to_dict()
                 user_birthplace = profile_data.get('birthplace', '不明')
-                
+
                 # 出身地の条件もチェック（指定されている場合）
                 birthplace_match = not search_birthplace or search_birthplace in user_birthplace
-                
+
                 if birthplace_match:
                     hobby_list = profile_data.get('hobby', [])
                     hobby_string = ', '.join(hobby_list) if isinstance(hobby_list, list) else str(hobby_list)
-                    
+
                     found_users.append({
                         "name": profile_data.get('name', '名前なし'),
+                        "name_roman": profile_data.get('name_roman', 'Unknown Name'),
                         "hobby": hobby_string,
                         "birthplace": user_birthplace,
                         "department": profile_data.get('department', '部署不明'),
@@ -98,14 +99,14 @@ def search_users():
             print(f"出身地「{search_birthplace}」で検索中...")
             # 全てのドキュメントを取得して出身地をチェック
             all_docs = db.collection(collection_name).stream()
-            
+
             for doc in all_docs:
                 if doc.id in processed_user_ids:
                     continue
-                
+
                 profile_data = doc.to_dict()
                 user_birthplace = profile_data.get('birthplace', '')
-                
+
                 # 出身地にマッチするかチェック
                 if search_birthplace in user_birthplace:
                     # 趣味の条件もチェック（指定されている場合）
@@ -113,13 +114,14 @@ def search_users():
                     if search_hobby:
                         hobby_list = profile_data.get('hobby', [])
                         hobby_match = search_hobby in hobby_list
-                    
+
                     if hobby_match:
                         hobby_list = profile_data.get('hobby', [])
                         hobby_string = ', '.join(hobby_list) if isinstance(hobby_list, list) else str(hobby_list)
-                        
+
                         found_users.append({
                             "name": profile_data.get('name', '名前なし'),
+                            "name_roman": profile_data.get('name_roman', 'Unknown Name'),
                             "hobby": hobby_string,
                             "birthplace": user_birthplace,
                             "department": profile_data.get('department', '部署不明'),

--- a/frontend/lib/constants/app_colors.dart
+++ b/frontend/lib/constants/app_colors.dart
@@ -10,6 +10,7 @@ class AppColors {
   static const Color secondaryPurple = Color(0xFF8B5CF6);
   static const Color accentCyan = Color(0xFF06B6D4);
   static const Color successGreen = Color(0xFF10B981);
+  static const Color primaryTeal = Color(0xFF009688);
 
   // === 背景色 ===
   static const Color backgroundLight = Color(0xFFF8FAFC);
@@ -139,11 +140,11 @@ class SearchHighlightColors {
   // メインハイライト色（赤系）
   static const Color matchText = Color(0xFFE53E3E);           // 濃い赤
   static const Color matchTextBold = Color(0xFFC53030);       // より濃い赤（太字用）
-  
+
   // 背景ハイライト（オプション）
   static const Color matchBackground = Color(0xFFFED7D7);     // 薄い赤背景
   static const Color matchBorder = Color(0xFFFEB2B2);        // 薄い赤ボーダー
-  
+
   // 通常テキスト
   static const Color normalText = Color(0xFF1E293B);         // ダークグレー
   static const Color secondaryText = Color(0xFF64748B);      // グレー


### PR DESCRIPTION
このプルリクエストは、フロントエンドにおける検索機能とユーザー選択機能の強化、ならびにバックエンドと定数の小規模な更新を行うものです。主な変更点として、ユーザー選択機能の追加、ユーザーデータ処理の改善、そしてインタラクティブ性とフィードバックを向上させるためのUI更新が含まれています。

### バックエンドの変更点：
・`search_users`関数内のユーザープロフィールデータに`name_roman`フィールドを追加し、検索結果にローマ字表記の名前が含まれるようにしました。

### フロントエンドの変更点：
**ユーザー選択とインタラクション：**
・`_toggleAllCurrentPageSelection`メソッドと`_toggleUserSelection`メソッドによるユーザー選択機能を導入し、現在のページに表示されているユーザーを個別または一括で選択・選択解除できるようになりました。 
・検索結果のUIに、個別のユーザー選択用のチェックボックスと、一括選択用の「すべて選択」チェックボックスを追加しました。

**UIの強化：**
・検索結果のUIを更新し、メンバー招待のためのチェックボックス利用を促す新しいカードと、選択したメンションをコピーするボタンを追加しました。 
・検索結果ヘッダーのレイアウトを改善し、選択コントロールとメンションコピーボタンを含めるようにしました。 

**データ処理：**
・検索結果のマッピングにname_romanを追加し、表示データにローマ字表記の名前が含まれるようにしました。 

・`_copySelectedMentions`メソッドを実装し、選択されたユーザーのメンションをフォーマットされた形式でクリップボードにコピーできるようにしました。エラーハンドリングとフィードバック機能も含まれています。 

**定数の更新：**
新しいUIコンポーネントで使用するために、`AppColorsにprimaryTeal`カラーを追加しました。 